### PR TITLE
Allow empty unquoted values

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -67,12 +67,14 @@ func MustParse(data string) map[string]string {
 }
 
 func parseValue(value string) string {
-	if value[0:1] == "'" && value[len(value)-1:] == "'" {
-		value = value[1 : len(value)-1]
-	} else if value[0:1] == `"` && value[len(value)-1:] == `"` {
-		value = value[1 : len(value)-1]
-		value = expandNewLines(value)
-		value = unescapeCharacters(value)
+	if len(value) > 1 {
+		if value[0:1] == "'" && value[len(value)-1:] == "'" {
+			value = value[1 : len(value)-1]
+		} else if value[0:1] == `"` && value[len(value)-1:] == `"` {
+			value = value[1 : len(value)-1]
+			value = expandNewLines(value)
+			value = unescapeCharacters(value)
+		}
 	}
 
 	return value

--- a/parse_test.go
+++ b/parse_test.go
@@ -35,6 +35,8 @@ OPTION_B=2
 OPTION_C= 3
 OPTION_D =4
 OPTION_E = 5
+OPTION_F=
+OPTION_G =
 `
 
 func TestDotEnvPlain(t *testing.T) {
@@ -54,6 +56,12 @@ func TestDotEnvPlain(t *testing.T) {
 	}
 	if env["OPTION_E"] != "5" {
 		t.Error("OPTION_E")
+	}
+	if env["OPTION_F"] != "" {
+		t.Error("OPTION_F")
+	}
+	if env["OPTION_G"] != "" {
+		t.Error("OPTION_G")
 	}
 }
 


### PR DESCRIPTION
Allows having empty, unquoted values in the dotenv file, e.g. (which is legal in Bash):
```
VALUE=
```

Prevents the following exception:

```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/direnv/direnv/vendor/github.com/direnv/go-dotenv.parseValue(0x0,
0x0, 0xb, 0xc42007e630)
  /private/tmp/direnv-20170927-27091-1c2f1z8/direnv-2.13.1/src/github.com/direnv/direnv/vendor/github.com/direnv/go-dotenv/parse.go:70
+0x15c
github.com/direnv/direnv/vendor/github.com/direnv/go-dotenv.Parse(0xc4200d8000,
0x12d, 0x12d, 0x32d, 0xc4200d8000)
  /private/tmp/direnv-20170927-27091-1c2f1z8/direnv-2.13.1/src/github.com/direnv/direnv/vendor/github.com/direnv/go-dotenv/parse.go:52
+0x135
main.glob..func4(0xc42007e450, 0xc42007e480, 0x3, 0x3, 0xc420010140,
0x4)
  /private/tmp/direnv-20170927-27091-1c2f1z8/direnv-2.13.1/src/github.com/direnv/direnv/cmd_dotenv.go:43
+0x103
main.CommandsDispatch(0xc42007e450, 0xc420010140, 0x4, 0x4,
0xc420057f70, 0x411dc2e)
  /private/tmp/direnv-20170927-27091-1c2f1z8/direnv-2.13.1/src/github.com/direnv/direnv/commands.go:95
+0x364
main.main()
  /private/tmp/direnv-20170927-27091-1c2f1z8/direnv-2.13.1/src/github.com/direnv/direnv/main.go:16
+0x84
```